### PR TITLE
Fix "indentation" in the assembly sources

### DIFF
--- a/src/vm64-common.s
+++ b/src/vm64-common.s
@@ -96,24 +96,24 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
            .quad L_zeroeq, L_zerone, L_zerolt, L_zerogt # 244 -- 247
            .quad L_ult, L_ugt, CPP_begin, CPP_while    # 248 -- 251
            .quad CPP_repeat, CPP_until, CPP_again, CPP_bye  # 252 -- 255
-	   .quad L_utmslash, L_utsslashmod, L_stsslashrem, L_udmstar   # 256 -- 259
-	   .quad CPP_included, CPP_include, CPP_source, CPP_refill # 260--263
-	   .quad CPP_state, CPP_allocate, CPP_free, CPP_resize  # 264--267
-	   .quad L_cputest, L_dsstar, CPP_compilecomma, L_nop   # 268--271
-	   .quad CPP_postpone, CPP_nondeferred, CPP_forget, C_forth_signal # 272--275
-	   .quad C_raise, C_setitimer, C_getitimer, C_us2fetch  # 276--279
-	   .quad C_tofloat, L_fsincos, C_facosh, C_fasinh # 280--283
-	   .quad C_fatanh, C_fcosh, C_fsinh, C_ftanh   # 284--287
-	   .quad C_falog, L_dzerolt, L_dmax, L_dmin    # 288--291
-	   .quad L_dtwostar, L_dtwodiv, CPP_uddot, L_within  # 292--295
-	   .quad CPP_twoliteral, C_tonumber, C_numberquery, CPP_sliteral   # 296--299
+           .quad L_utmslash, L_utsslashmod, L_stsslashrem, L_udmstar   # 256 -- 259
+           .quad CPP_included, CPP_include, CPP_source, CPP_refill # 260--263
+           .quad CPP_state, CPP_allocate, CPP_free, CPP_resize  # 264--267
+           .quad L_cputest, L_dsstar, CPP_compilecomma, L_nop   # 268--271
+           .quad CPP_postpone, CPP_nondeferred, CPP_forget, C_forth_signal # 272--275
+           .quad C_raise, C_setitimer, C_getitimer, C_us2fetch  # 276--279
+           .quad C_tofloat, L_fsincos, C_facosh, C_fasinh # 280--283
+           .quad C_fatanh, C_fcosh, C_fsinh, C_ftanh   # 284--287
+           .quad C_falog, L_dzerolt, L_dmax, L_dmin    # 288--291
+           .quad L_dtwostar, L_dtwodiv, CPP_uddot, L_within  # 292--295
+           .quad CPP_twoliteral, C_tonumber, C_numberquery, CPP_sliteral   # 296--299
            .quad L_nop, L_nop, L_nop, L_nop            # 300--303
            .quad L_nop, L_nop, L_nop, L_nop            # 304--307
            .quad L_nop, L_nop, L_nop, L_blank          # 308--311
            .quad L_slashstring, C_trailing, C_parse, L_nop  # 312--315
-	   .quad L_nop, L_nop, L_nop, L_nop            # 316--319
+           .quad L_nop, L_nop, L_nop, L_nop            # 316--319
            .quad C_dlopen, C_dlerror, C_dlsym, C_dlclose # 320--323
-	   .quad C_usec, CPP_alias, L_nop, L_nop       # 324--327
+           .quad C_usec, CPP_alias, L_nop, L_nop       # 324--327
            .quad L_nop, L_nop, CPP_wordlist, CPP_forthwordlist               # 328--331
            .quad CPP_getcurrent, CPP_setcurrent, CPP_getorder, CPP_setorder  # 332--335
            .quad CPP_searchwordlist, CPP_definitions, CPP_vocabulary, L_nop  # 336--339
@@ -123,8 +123,8 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
            .quad L_nop, L_nop, L_nop, L_nop            # 352--355
            .quad L_nop, L_nop, L_nop, L_nop            # 356--359
            .quad L_precision, L_setprecision, L_nop, CPP_fsdot   # 360--363
-	   .quad L_nop, L_nop, C_fexpm1, C_flnp1	      # 364--367
-	   .quad L_nop, L_nop, L_f2drop, L_f2dup	      # 368--371
+           .quad L_nop, L_nop, C_fexpm1, C_flnp1	      # 364--367
+           .quad L_nop, L_nop, L_f2drop, L_f2dup	      # 368--371
 .text
 	.align WSIZE
 .global JumpTable
@@ -134,7 +134,7 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
 
 .macro LDSP                      # load stack ptr into rbx reg
   .ifndef __FAST__
-        movq GlobalSp(%rip), %rbx
+	movq GlobalSp(%rip), %rbx
   .endif
 .endm
 
@@ -193,7 +193,7 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
 .macro UNLOOP
 	addq $3*WSIZE, GlobalRp(%rip)  # terminal count reached, discard top 3 items
   .ifndef __FAST__
-        addq $3, GlobalRtp(%rip)
+	addq $3, GlobalRtp(%rip)
   .endif
 .endm
 
@@ -212,24 +212,24 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
 
 
 .macro DROP                     # increment DSP by 1 cell; assume DSP in rbx reg
-        INC_DSP
+	INC_DSP
 	STSP
 	INC_DTSP
 .endm
 
 
 .macro DUP                      # assume DSP in rbx reg
-        movq WSIZE(%rbx), %rcx
-        mov %rcx, (%rbx)
+	movq WSIZE(%rbx), %rcx
+	mov %rcx, (%rbx)
 	DEC_DSP
 	STSP
   .ifndef __FAST__
-        movq GlobalTp(%rip), %rcx
-        movb 1(%rcx), %al
-        movb %al, (%rcx)
+	movq GlobalTp(%rip), %rcx
+	movb 1(%rcx), %al
+	movb %al, (%rcx)
 	xor %rax, %rax
-   .endif
-        DEC_DTSP
+  .endif
+	DEC_DTSP
 .endm
 
 
@@ -283,12 +283,12 @@ JumpTable: .quad L_false, L_true, L_cells, L_cellplus # 0 -- 3
 
 // Error jumps
 E_not_addr:
-        mov $E_NOT_ADDR, %rax
-        ret
+	mov $E_NOT_ADDR, %rax
+	ret
 
 E_ret_stk_corrupt:
-        mov $E_RET_STK_CORRUPT, %rax
-        ret
+	mov $E_RET_STK_CORRUPT, %rax
+	ret
 
 E_div_zero:
 	mov $E_DIV_ZERO, %rax
@@ -307,14 +307,14 @@ L_initfpu:
 	fnstcw NDPcw(%rip)           # save the NDP control word
 	mov NDPcw(%rip), %rcx
 	andb $240, %ch         # mask the high byte
-        orb  $2,  %ch          # set double precision, round near
-        mov %rcx, (%rbx)
+	orb  $2,  %ch          # set double precision, round near
+	mov %rcx, (%rbx)
 	fldcw (%rbx)
 	ret
 
 L_nop:
-        mov $E_UNKNOWN_OP, %rax   # unknown operation
-        ret
+	mov $E_UNKNOWN_OP, %rax   # unknown operation
+	ret
 L_quit:
 	mov BottomOfReturnStack(%rip), %rax	# clear the return stacks
 	mov %rax, GlobalRp(%rip)
@@ -335,35 +335,35 @@ L_abort:
 	jmp L_quit
 
 L_jz:
-        LDSP
+	LDSP
 	DROP
-        mov (%rbx), %rax
-        cmpq $0, %rax
-        jz jz1
+	mov (%rbx), %rax
+	cmpq $0, %rax
+	jz jz1
 	movq $WSIZE, %rax
-        add %rax, %rbp       # do not jump
+	add %rax, %rbp       # do not jump
 	xor %rax, %rax
-        NEXT
+	NEXT
 jz1:    mov %rbp, %rcx
-        inc %rcx
-        mov (%rcx), %rax       # get the relative jump count
-        dec %rax
-        add %rax, %rbp
+	inc %rcx
+	mov (%rcx), %rax       # get the relative jump count
+	dec %rax
+	add %rax, %rbp
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_jnz:				# not implemented
 	ret
 
 L_jmp:
-        mov %rbp, %rcx
-        inc %rcx
-        mov (%rcx), %rax       # get the relative jump count
-        add %rax, %rcx
-        sub $2, %rcx
-        mov %rcx, %rbp		# set instruction ptr
+	mov %rbp, %rcx
+	inc %rcx
+	mov (%rcx), %rax       # get the relative jump count
+	add %rax, %rcx
+	sub $2, %rcx
+	mov %rcx, %rbp		# set instruction ptr
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_calladdr:
 	inc %rbp
@@ -399,7 +399,7 @@ L_base:
 L_precision:
 	LDSP
 	mov Precision(%rip), %rcx
-        mov %rcx, (%rbx)
+	mov %rcx, (%rbx)
 	DEC_DSP
 	STSP
 	STD_IVAL
@@ -459,27 +459,27 @@ L_dfloats:
 L_dup:
 	LDSP
 	DUP
-        NEXT
+	NEXT
 
 L_drop:
 	LDSP
-        DROP
-        NEXT
+	DROP
+	NEXT
 
 L_inc:
 	LDSP
-        incq WSIZE(%rbx)
-        NEXT
+	incq WSIZE(%rbx)
+	NEXT
 
 L_dec:
 	LDSP
-        decq WSIZE(%rbx)
-        NEXT
+	decq WSIZE(%rbx)
+	NEXT
 
 L_neg:
 	LDSP
 	negq WSIZE(%rbx)
-        NEXT
+	NEXT
 
 L_lshift:
 	LDSP
@@ -522,8 +522,8 @@ L_sub:
 	DROP         # result will have type of first operand
 	mov (%rbx), %rax
 	sub %rax, WSIZE(%rbx)	
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
 
 L_mul:
 	LDSP
@@ -535,11 +535,11 @@ L_mul:
 	imulq (%rbx)
 	mov %rax, (%rbx)
    .ifdef __FAST__
-        sub %rcx, %rbx
+	sub %rcx, %rbx
    .endif
 	INC_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_stod:
 	STOD
@@ -547,16 +547,16 @@ L_stod:
 
 L_fabs:
 	LDSP
-        fld WSIZE(%rbx)
-        fabs
-        fstp WSIZE(%rbx)
-        NEXT
+	fld WSIZE(%rbx)
+	fabs
+	fstp WSIZE(%rbx)
+	NEXT
 L_fneg:
-        LDSP
-        fld WSIZE(%rbx)
-        fchs
-        fstp WSIZE(%rbx)
-        NEXT
+	LDSP
+	fld WSIZE(%rbx)
+	fchs
+	fstp WSIZE(%rbx)
+	NEXT
 
 L_fsqrt:
 	LDSP
@@ -681,12 +681,12 @@ L_ftrunc:
 	INC_DSP
 	fld (%rbx)
 	fnstcw NDPcw(%rip)            # save NDP control word
-        mov NDPcw(%rip), %rcx
+	mov NDPcw(%rip), %rcx
 	movb $12, %ch
 	mov %rcx, (%rbx)
 	fldcw (%rbx)
 	frndint
-        fldcw NDPcw(%rip)             # restore NDP control word
+	fldcw NDPcw(%rip)             # restore NDP control word
 	fstp (%rbx)
 	DEC_DSP
 	NEXT
@@ -694,70 +694,70 @@ L_ftrunc:
 L_fadd:
 	LDSP
 	mov $WSIZE, %rax
-        add %rax, %rbx
-        fld (%rbx)
+	add %rax, %rbx
+	fld (%rbx)
 	sal $1, %rax
-        add %rax, %rbx
-        fadd (%rbx)
-        fstp (%rbx)
+	add %rax, %rbx
+	fadd (%rbx)
+	fstp (%rbx)
 	DEC_DSP
 	STSP
 	INC2_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_fsub:
 	LDSP
 	mov $3*WSIZE, %rax
 	add %rax, %rbx
-        fld (%rbx)
+	fld (%rbx)
 	sub $WSIZE, %rax
 	sub %rax, %rbx
-        fsub (%rbx)
-        add %rax, %rbx
-        fstp (%rbx)
-        DEC_DSP
+	fsub (%rbx)
+	add %rax, %rbx
+	fstp (%rbx)
+	DEC_DSP
 	STSP
 	INC2_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_fmul:
 	LDSP
 	mov $WSIZE, %rax
-        add %rax, %rbx
-        fld (%rbx)
-        add %rax, %rbx
+	add %rax, %rbx
+	fld (%rbx)
+	add %rax, %rbx
 	mov %rbx, %rcx
 	add %rax, %rbx
-        fmul (%rbx)
-        fstp (%rbx)
-        mov %rcx, %rbx
+	fmul (%rbx)
+	fstp (%rbx)
+	mov %rcx, %rbx
 	STSP
 	INC2_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_fdiv:
 	LDSP
 	mov $WSIZE, %rax
-        add %rax, %rbx
-        fld (%rbx)
-        add %rax, %rbx
+	add %rax, %rbx
+	fld (%rbx)
+	add %rax, %rbx
 	mov %rbx, %rcx
 	add %rax, %rbx
-        fdivr (%rbx)
-        fstp (%rbx)
-        mov %rcx, %rbx
+	fdivr (%rbx)
+	fstp (%rbx)
+	mov %rcx, %rbx
 	STSP
 	INC2_DTSP
 	xor %rax, %rax
 	NEXT
 
 L_backslash:
-        mov pTIB(%rip), %rcx
-        movb $0, (%rcx)
-        NEXT
+	mov pTIB(%rip), %rcx
+	movb $0, (%rcx)
+	NEXT
 
 
 	.comm GlobalSp, WSIZE,WSIZE

--- a/src/vm64-fast.s
+++ b/src/vm64-fast.s
@@ -20,7 +20,7 @@
 
 .macro SWAP
 	movl %ebx, %eax
-        addl $WSIZE, %eax
+	addl $WSIZE, %eax
 	movl (%eax), %ecx
 	addl $WSIZE, %eax
 	movl (%eax), %edx
@@ -32,8 +32,8 @@
 
 
 .macro OVER
-        movl 2*WSIZE(%ebx), %ecx
-        movl %ecx, (%ebx)
+	movl 2*WSIZE(%ebx), %ecx
+	movl %ecx, (%ebx)
 	DEC_DSP
 .endm
 	
@@ -96,7 +96,7 @@
 	movl %ecx, (%edx)
 	subl %eax, %edx
 	movl %edx, GlobalRp
-        xor %eax, %eax
+	xor %eax, %eax
 .endm
 
 .macro POP_R
@@ -113,16 +113,16 @@
 .macro FETCH
 	movl %ebx, %edx	
 	addl $WSIZE, %edx
-        movl (%edx), %eax	
-        movl (%eax), %eax
+	movl (%edx), %eax
+	movl (%eax), %eax
 	movl %eax, (%edx)
 	xor %eax, %eax
 .endm
 	
 .macro STORE
 	movl $WSIZE, %eax
-        addl %eax, %ebx
-        movl (%ebx), %ecx	# address to store to in ecx
+	addl %eax, %ebx
+	movl (%ebx), %ecx	# address to store to in ecx
 	addl %eax, %ebx
 	movl (%ebx), %edx	# value to store in edx
 	movl %edx, (%ecx)
@@ -268,9 +268,9 @@
 
 .macro STARSLASH
 	movl $2*WSIZE, %eax
-        addl %eax, %ebx
-        movl WSIZE(%ebx), %eax
-        imull (%ebx)
+	addl %eax, %ebx
+	movl WSIZE(%ebx), %eax
+	imull (%ebx)
 	idivl -WSIZE(%ebx)
 	movl %eax, WSIZE(%ebx)
 	xor %eax, %eax
@@ -306,21 +306,21 @@
 .global vm
 	.type	vm,@function
 vm:	
-        pushl %ebp
-        pushl %ebx
-        pushl %ecx
-        pushl %edx
+	pushl %ebp
+	pushl %ebx
+	pushl %ecx
+	pushl %edx
 	pushl GlobalIp
 	pushl vmEntryRp
-        movl %esp, %ebp
-        movl 28(%ebp), %ebp     # load the Forth instruction pointer
-        movl %ebp, GlobalIp
+	movl %esp, %ebp
+	movl 28(%ebp), %ebp     # load the Forth instruction pointer
+	movl %ebp, GlobalIp
 	movl GlobalRp, %eax
 	movl %eax, vmEntryRp
 	xor %eax, %eax
 	movl GlobalSp, %ebx
 next:
-        movb (%ebp), %al         # get the opcode
+	movb (%ebp), %al         # get the opcode
 	movl JumpTable(,%eax,4), %ecx	# machine code address of word
 	xor %eax, %eax          # clear error code
 	call *%ecx		# call the word
@@ -331,33 +331,33 @@ next:
 	cmpb $0, %al		 # check for error
 	jz next        
 exitloop:
-        cmpl $OP_RET, %eax         # return from vm?
-        jnz vmexit
-        xor %eax, %eax            # clear the error
+	cmpl $OP_RET, %eax         # return from vm?
+	jnz vmexit
+	xor %eax, %eax            # clear the error
 vmexit:
 	pop vmEntryRp
 	pop GlobalIp
 	pop %edx
-        pop %ecx
-        pop %ebx
-        pop %ebp
-        ret
+	pop %ecx
+	pop %ebx
+	pop %ebp
+	ret
 
 L_ret:
 	movl vmEntryRp, %eax		# Return Stack Ptr on entry to VM
 	movl GlobalRp, %ecx
 	cmpl %eax, %ecx
 	jl ret1
-        movl $OP_RET, %eax             # exhausted the return stack so exit vm
-        ret
+	movl $OP_RET, %eax             # exhausted the return stack so exit vm
+	ret
 ret1:
 	addl $WSIZE, %ecx
-        movl %ecx, GlobalRp
+	movl %ecx, GlobalRp
 ret2:   movl (%ecx), %eax
 	movl %eax, GlobalIp		# reset the instruction ptr
-        xorl %eax, %eax
+	xorl %eax, %eax
 retexit:
-        ret
+	ret
 
 L_tobody:
 	INC_DSP
@@ -519,7 +519,7 @@ L_call:
 
 L_push_r:
 	PUSH_R
-        NEXT
+	NEXT
 
 L_pop_r:
 	POP_R
@@ -554,30 +554,30 @@ L_twopop_r:
 	NEXT
 
 L_puship:
-        movl %ebp, %eax
-        movl GlobalRp, %ecx
-        mov %eax, (%ecx)
+	movl %ebp, %eax
+	movl GlobalRp, %ecx
+	mov %eax, (%ecx)
 	movl $WSIZE, %eax
-        subl %eax, GlobalRp
-        xor %eax, %eax
-        NEXT
+	subl %eax, GlobalRp
+	xor %eax, %eax
+	NEXT
 
 L_execute:	
-        movl %ebp, %ecx
-        movl GlobalRp, %edx
-        movl %ecx, (%edx)
+	movl %ebp, %ecx
+	movl GlobalRp, %edx
+	movl %ecx, (%edx)
 	movl $WSIZE, %eax 
-        subl %eax, %edx 
+	subl %eax, %edx
 	movl %edx, GlobalRp
-        addl %eax, %ebx
-        movl (%ebx), %eax
+	addl %eax, %ebx
+	movl (%ebx), %eax
 	decl %eax
 	movl %eax, %ebp
-        xorl %eax, %eax
-        NEXT
+	xorl %eax, %eax
+	NEXT
 
 L_definition:
-        movl %ebp, %eax
+	movl %ebp, %eax
 	incl %eax
 	movl (%eax), %ecx # address to execute
 	addl $3, %eax
@@ -588,17 +588,17 @@ L_definition:
 	movl %eax, GlobalRp
 	decl %ecx
 	movl %ecx, %ebp
-        xorl %eax, %eax	
+	xorl %eax, %eax
 	NEXT
 
 L_rfetch:
-        movl GlobalRp, %ecx
+	movl GlobalRp, %ecx
 	movl $WSIZE, %eax
-        addl %eax, %ecx
-        movl (%ecx), %ecx
-        movl %ecx, (%ebx)
-        subl %eax, %ebx
-        xorl %eax, %eax
+	addl %eax, %ecx
+	movl (%ecx), %ecx
+	movl %ecx, (%ebx)
+	subl %eax, %ebx
+	xorl %eax, %eax
 	NEXT
 
 L_tworfetch:
@@ -634,47 +634,47 @@ L_spfetch:
 	NEXT
 
 L_i:
-        movl GlobalRp, %ecx
-        movl 3*WSIZE(%ecx), %eax
-        movl %eax, (%ebx)
+	movl GlobalRp, %ecx
+	movl 3*WSIZE(%ecx), %eax
+	movl %eax, (%ebx)
 	movl $WSIZE, %eax
-        subl %eax, %ebx 
-        xorl %eax, %eax
-        NEXT
+	subl %eax, %ebx
+	xorl %eax, %eax
+	NEXT
 
 L_j:
-        movl GlobalRp, %ecx
-        movl 6*WSIZE(%ecx), %eax
-        movl %eax, (%ebx)
+	movl GlobalRp, %ecx
+	movl 6*WSIZE(%ecx), %eax
+	movl %eax, (%ebx)
 	movl $WSIZE, %eax
-        subl %eax, %ebx
-        xorl %eax, %eax
-        NEXT	
+	subl %eax, %ebx
+	xorl %eax, %eax
+	NEXT
 
 L_loop:
-        movl GlobalRp, %ebx	
+	movl GlobalRp, %ebx
 	movl $WSIZE, %eax
 	addl %eax, %ebx
 	movl (%ebx), %edx
 	addl %eax, %ebx
 	movl (%ebx), %ecx
 	addl %eax, %ebx
-        movl (%ebx), %eax
-        incl %eax
+	movl (%ebx), %eax
+	incl %eax
 	cmpl %ecx, %eax	
-        jz L_unloop
+	jz L_unloop
 loop1:	
-        movl %eax, (%ebx)	# set loop counter to next value
+	movl %eax, (%ebx)	# set loop counter to next value
 	movl %edx, %ebp		# set instruction ptr to start of loop
 	movl GlobalSp, %ebx
-        xorl %eax, %eax
-        NEXT
+	xorl %eax, %eax
+	NEXT
 
 L_unloop:  
 	UNLOOP
 	movl GlobalSp, %ebx
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_plusloop:
 	pushl %ebp
@@ -682,7 +682,7 @@ L_plusloop:
 	addl %eax, %ebx
 	movl (%ebx), %ebp	# get loop increment 
 	movl %ebx, GlobalSp
-        movl GlobalRp, %ebx
+	movl GlobalRp, %ebx
 	addl %eax, %ebx		# get ip and save in edx
 	movl (%ebx), %edx
 	addl %eax, %ebx
@@ -738,9 +738,9 @@ L_count:
 	NEXT
 
 L_ival:
-        movl %ebp, %ecx
-        incl %ecx
-        movl (%ecx), %eax
+	movl %ebp, %ecx
+	incl %ecx
+	movl (%ecx), %eax
 	addl $WSIZE-1, %ecx
 	movl %ecx, %ebp
 	movl %eax, (%ebx)
@@ -772,10 +772,10 @@ L_ptr:
 	NEXT
 
 L_fval:
-        movl %ebp, %ecx
-        incl %ecx
-        DEC_DSP
-        movl (%ecx), %eax
+	movl %ebp, %ecx
+	incl %ecx
+	DEC_DSP
+	movl (%ecx), %eax
 	movl %eax, (%ebx)
 	movl WSIZE(%ecx), %eax
 	movl %eax, WSIZE(%ebx)
@@ -850,20 +850,20 @@ L_zerogt:
 	NEXT
 
 L_within:                          # stack: a b c
-        movl 2*WSIZE(%ebx), %ecx   # ecx = b
+	movl 2*WSIZE(%ebx), %ecx   # ecx = b
 	movl WSIZE(%ebx), %eax     # eax = c
 	subl %ecx, %eax            # eax = c - b
 	INC_DSP     
 	INC_DSP
 	movl WSIZE(%ebx), %edx     # edx = a
-        subl %ecx, %edx            # edx = a - b
+	subl %ecx, %edx            # edx = a - b
 	cmpl %eax, %edx
 	movl $0, %eax
 	setb %al
 	negl %eax
 	movl %eax, WSIZE(%ebx)
 	xorl %eax, %eax      
-        NEXT
+	NEXT
 
 L_deq:
 	INC_DSP
@@ -951,11 +951,11 @@ L_querydupexit:
 
 L_swap:
 	SWAP
-        NEXT
+	NEXT
 
 L_over:
 	OVER
-        NEXT
+	NEXT
 
 L_rot:
 	pushl %ebp
@@ -992,14 +992,14 @@ L_minusrot:
 	NEXT
 
 L_nip:
-        SWAP
-        addl $WSIZE, %ebx
-        NEXT
+	SWAP
+	addl $WSIZE, %ebx
+	NEXT
 
 L_tuck:
-        SWAP
-        OVER
-        NEXT
+	SWAP
+	OVER
+	NEXT
 
 L_pick:                        
 	movl %ebx, %ecx
@@ -1055,11 +1055,11 @@ L_depth:
 	movl $WSIZE, %eax
 	subl %eax, GlobalSp
 	xorl %eax, %eax
-        ret
+	ret
 
 L_2drop:
 	FDROP
-        NEXT
+	NEXT
 
 L_f2drop:
 	FDROP
@@ -1073,15 +1073,15 @@ L_f2dup:
 
 L_2dup:
 	FDUP
-        NEXT
+	NEXT
 
 L_2swap:
 	FSWAP	
-        NEXT
+	NEXT
 
 L_2over:
 	FOVER
-        NEXT
+	NEXT
 
 L_2rot:
 	INC_DSP
@@ -1103,7 +1103,7 @@ L_2rot:
 	movl %eax, (%ebx)
 	movl GlobalSp, %ebx
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_question:
 	FETCH
@@ -1131,7 +1131,7 @@ L_cfetch:
 	movb (%ecx), %al
 	movl %eax, (%edx)
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_cstore:
 	movl $WSIZE, %eax
@@ -1149,7 +1149,7 @@ L_wfetch:
 	cwde
 	movl %eax, WSIZE(%ebx)
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_wstore:
 	movl $WSIZE, %eax
@@ -1159,32 +1159,32 @@ L_wstore:
 	movl (%ebx), %edx
 	movw %dx, (%ecx)
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_sffetch:
 	movl $WSIZE, %eax
 	movl %ebx, %ecx
-        addl %eax, %ecx
-        movl (%ecx), %ecx
-        flds (%ecx)
-        fstpl (%ebx)
-        subl %eax, %ebx
+	addl %eax, %ecx
+	movl (%ecx), %ecx
+	flds (%ecx)
+	fstpl (%ebx)
+	subl %eax, %ebx
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_sfstore:
 	movl $WSIZE, %eax
-        addl %eax, %ebx
-        addl %eax, %ebx
-        fldl (%ebx)              # load the f number into NDP
+	addl %eax, %ebx
+	addl %eax, %ebx
+	fldl (%ebx)              # load the f number into NDP
 	movl %ebx, %edx
-        subl %eax, %ebx
-        movl (%ebx), %ebx          # load the dest address
-        fstps (%ebx)             # store as single precision float
+	subl %eax, %ebx
+	movl (%ebx), %ebx          # load the dest address
+	fstps (%ebx)             # store as single precision float
 	movl %edx, %ebx
-        addl %eax, %ebx
+	addl %eax, %ebx
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_dffetch:
 	movl %ebx, %edx
@@ -1233,7 +1233,7 @@ max1:
 	movl %eax, WSIZE(%ebx)
 maxexit:
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_min:
 	movl $WSIZE, %eax
@@ -1248,7 +1248,7 @@ min1:
 	movl %eax, WSIZE(%ebx)
 minexit:
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_dmax:
 	FOVER
@@ -1283,59 +1283,59 @@ dmin1:
 
 #  L_dtwostar and L_dtwodiv are valid for two's-complement systems 
 L_dtwostar:
-        INC_DSP
-        movl WSIZE(%ebx), %eax
-        movl %eax, %ecx
-        sall $1, %eax
-        movl %eax, WSIZE(%ebx)
-        shrl $31, %ecx
-        movl (%ebx), %eax
-        sall $1, %eax
-        orl  %ecx, %eax
-        movl %eax, (%ebx)
-        DEC_DSP
-        xorl %eax, %eax
-        NEXT
+	INC_DSP
+	movl WSIZE(%ebx), %eax
+	movl %eax, %ecx
+	sall $1, %eax
+	movl %eax, WSIZE(%ebx)
+	shrl $31, %ecx
+	movl (%ebx), %eax
+	sall $1, %eax
+	orl  %ecx, %eax
+	movl %eax, (%ebx)
+	DEC_DSP
+	xorl %eax, %eax
+	NEXT
 
 L_dtwodiv:
 	INC_DSP
 	movl (%ebx), %eax
-        movl %eax, %ecx
-        sarl $1, %eax
-        movl %eax, (%ebx)
-        shll $31, %ecx
-        movl WSIZE(%ebx), %eax
-        shrl $1, %eax
-        orl %ecx, %eax
-        movl %eax, WSIZE(%ebx)
-        DEC_DSP
-        xorl %eax, %eax
-        NEXT
+	movl %eax, %ecx
+	sarl $1, %eax
+	movl %eax, (%ebx)
+	shll $31, %ecx
+	movl WSIZE(%ebx), %eax
+	shrl $1, %eax
+	orl %ecx, %eax
+	movl %eax, WSIZE(%ebx)
+	DEC_DSP
+	xorl %eax, %eax
+	NEXT
 
 L_add:
 	movl $WSIZE, %eax
 	addl %eax, %ebx
 	movl (%ebx), %eax
 	addl %eax, WSIZE(%ebx)
-        xorl %eax, %eax
-        NEXT
+	xorl %eax, %eax
+	NEXT
 
 L_div:
 	movl $WSIZE, %eax
-        addl %eax, %ebx
-        movl (%ebx), %eax
-        cmpl $0, %eax
+	addl %eax, %ebx
+	movl (%ebx), %eax
+	cmpl $0, %eax
 	jz   E_div_zero
 	INC_DSP
-        movl (%ebx), %eax
+	movl (%ebx), %eax
 	cdq
-        idivl -WSIZE(%ebx)
-        movl %eax, (%ebx)
+	idivl -WSIZE(%ebx)
+	movl %eax, (%ebx)
 	DEC_DSP
 	xorl %eax, %eax
 divexit:
 	movl %ebx, GlobalSp
-        ret
+	ret
 
 L_mod:
 	call L_div
@@ -1411,11 +1411,11 @@ L_dnegate:
 	ret
 
 L_dplus:
-        movl GlobalSp, %ebx
+	movl GlobalSp, %ebx
 	DPLUS
 #	NEXT
-        movl %ebx, GlobalSp
-        ret
+	movl %ebx, GlobalSp
+	ret
 
 L_dminus:
 	movl GlobalSp, %ebx
@@ -1517,15 +1517,15 @@ L_mplus:
 L_mslash:
 	movl $WSIZE, %eax
 	addl %eax, %ebx
-        movl (%ebx), %ecx
+	movl (%ebx), %ecx
 	addl %eax, %ebx
-        cmpl $0, %ecx
+	cmpl $0, %ecx
 	je   E_div_zero
-        movl (%ebx), %edx
+	movl (%ebx), %edx
 	addl %eax, %ebx
 	movl (%ebx), %eax
-        idivl %ecx
-        movl %eax, (%ebx)
+	idivl %ecx
+	movl %eax, (%ebx)
 	DEC_DSP
 	xor %eax, %eax		
 	NEXT
@@ -1588,32 +1588,32 @@ L_utsslashmod:
 
 L_tabs:
 # Triple length absolute value (needed by L_stsslashrem, STS/REM)
-        movl WSIZE(%ebx), %ecx
-        movl %ecx, %eax
-        cmpl $0, %eax
-        jl tabs1
-        xor %eax, %eax
-        ret
+	movl WSIZE(%ebx), %ecx
+	movl %ecx, %eax
+	cmpl $0, %eax
+	jl tabs1
+	xor %eax, %eax
+	ret
 tabs1:
-        addl $3*WSIZE, %ebx
-        movl (%ebx), %eax
-        clc
-        subl $1, %eax
-        notl %eax
-        movl %eax, (%ebx)
+	addl $3*WSIZE, %ebx
+	movl (%ebx), %eax
+	clc
+	subl $1, %eax
+	notl %eax
+	movl %eax, (%ebx)
 	DEC_DSP
 	movl (%ebx), %eax
 	sbbl $0, %eax
 	notl %eax
 	movl %eax, (%ebx)
-        movl %ecx, %eax
-        sbbl $0, %eax
-        notl %eax
-        movl %eax, -WSIZE(%ebx)
+	movl %ecx, %eax
+	sbbl $0, %eax
+	notl %eax
+	movl %eax, -WSIZE(%ebx)
 	subl $2*WSIZE, %ebx
 	movl %ebx, GlobalSp
-        xor %eax, %eax
-        ret
+	xor %eax, %eax
+	ret
 
 L_stsslashrem:
 # Divide signed triple length by signed single length to give a
@@ -1842,12 +1842,12 @@ L_smslashrem:
 L_stof:
 	movl $WSIZE, %eax
 	movl %ebx, %ecx
-        addl %eax, %ecx
-        fildl (%ecx)
-        fstpl (%ebx)
-        subl %eax, %ebx
+	addl %eax, %ecx
+	fildl (%ecx)
+	fstpl (%ebx)
+	subl %eax, %ebx
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_dtof:
 	movl $WSIZE, %eax
@@ -1856,20 +1856,20 @@ L_dtof:
 	movl (%ecx), %eax
 	xchgl WSIZE(%ecx), %eax
 	movl %eax, (%ecx)
-        fildq (%ecx)
-        fstpl (%ecx)
+	fildq (%ecx)
+	fstpl (%ecx)
 	xorl %eax, %eax	
 	NEXT
 	
 L_froundtos:
 	movl $WSIZE, %eax
-        addl %eax, %ebx
+	addl %eax, %ebx
 	movl %ebx, %ecx
-        fldl (%ecx)
-        addl %eax, %ecx
-        fistpl (%ecx)
+	fldl (%ecx)
+	addl %eax, %ecx
+	fistpl (%ecx)
 	xorl %eax, %eax
-        NEXT
+	NEXT
 
 L_ftrunctos:
 	movl $WSIZE, %eax

--- a/src/vm64.s
+++ b/src/vm64.s
@@ -23,47 +23,47 @@
 .macro FETCH op
 	movq GlobalTp(%rip), %rbx
 	inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz E_not_addr
-        movb \op, (%rbx)
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz E_not_addr
+	movb \op, (%rbx)
 	LDSP
 	INC_DSP
-        mov (%rbx), %rax	
-        mov (%rax), %rax
+	mov (%rbx), %rax
+	mov (%rax), %rax
 	mov %rax, (%rbx)
 	xor %rax, %rax
 .endm
 
 .macro SWAP
-        LDSP
-        INC_DSP
+	LDSP
+	INC_DSP
 	mov (%rbx), %rax
 	INC_DSP
 	mov (%rbx), %rcx
 	mov %rax, (%rbx)
 	mov %rcx, -WSIZE(%rbx)
-        movq GlobalTp(%rip), %rbx
-        inc %rbx
+	movq GlobalTp(%rip), %rbx
+	inc %rbx
 	movb (%rbx), %al
 	inc %rbx
 	movb (%rbx), %cl
 	movb %al, (%rbx)
 	movb %cl, -1(%rbx)
-        xor %rax, %rax
+	xor %rax, %rax
 .endm
 
 .macro OVER
-        LDSP
-        movq 2*WSIZE(%rbx), %rax
-        mov %rax, (%rbx)
+	LDSP
+	movq 2*WSIZE(%rbx), %rax
+	mov %rax, (%rbx)
 	DEC_DSP
 	STSP
-        movq GlobalTp(%rip), %rbx
-        movb 2(%rbx), %al
-        movb %al, (%rbx)
-        decq GlobalTp(%rip)
-        xor %rax, %rax
+	movq GlobalTp(%rip), %rbx
+	movb 2(%rbx), %al
+	movb %al, (%rbx)
+	decq GlobalTp(%rip)
+	xor %rax, %rax
 .endm
 
 .macro FDUP
@@ -92,7 +92,7 @@
 .macro FDROP
 	movq $2*WSIZE, %rax
 	addq %rax, GlobalSp(%rip)
-        INC2_DTSP
+	INC2_DTSP
 	xor %rax, %rax
 .endm
 
@@ -151,7 +151,7 @@
 	LDSP
 	movq $WSIZE, %rax
 	add %rax, %rbx	
-        STSP
+	STSP
 	mov (%rbx), %rcx
 	movq GlobalRp(%rip), %rbx
 	mov %rcx, (%rbx)
@@ -165,7 +165,7 @@
 	movb %al, (%rbx)
 	dec %rbx
 	movq %rbx, GlobalRtp(%rip)
-        xor %rax, %rax
+	xor %rax, %rax
 .endm
 
 	
@@ -380,10 +380,10 @@
 	
 .macro STARSLASH
 	movq $2*WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        LDSP
-        movq WSIZE(%rbx), %rax
-        imulq (%rbx)
+	addq %rax, GlobalSp(%rip)
+	LDSP
+	movq WSIZE(%rbx), %rax
+	imulq (%rbx)
 	idivq -WSIZE(%rbx)
 	mov %rax, WSIZE(%rbx)
 	INC2_DTSP
@@ -421,17 +421,17 @@
 .global vm
 	.type	vm,@function
 vm:
-        push %rbp
-        push %rbx
+	push %rbp
+	push %rbx
 	pushq GlobalIp(%rip)
 	pushq vmEntryRp(%rip)
 	movq %rdi, %rbp         # load the Forth instruction pointer
-        movq %rbp, GlobalIp(%rip)
+	movq %rbp, GlobalIp(%rip)
 	movq GlobalRp(%rip), %rax
 	movq %rax, vmEntryRp(%rip)
 	xor %rax, %rax
 next:
-        movb (%rbp), %al         # get the opcode
+	movb (%rbp), %al         # get the opcode
 	leaq JumpTable(%rip), %rcx
 	movq (%rcx,%rax,WSIZE), %rbx	# machine code address of word
 	xor %rax, %rax           # clear error code
@@ -442,36 +442,36 @@ next:
 	cmpb $0, %al		 # check for error
 	jz next        
 exitloop:
-        cmpq $OP_RET, %rax       # return from vm?
-        jnz vmexit
-        xor %rax, %rax           # clear the error
+	cmpq $OP_RET, %rax       # return from vm?
+	jnz vmexit
+	xor %rax, %rax           # clear the error
 vmexit:
 	popq vmEntryRp(%rip)
 	popq GlobalIp(%rip)
-        pop %rbx
-        pop %rbp
-        ret
+	pop %rbx
+	pop %rbp
+	ret
 
 L_ret:
 	movq vmEntryRp(%rip), %rax		# Return Stack Ptr on entry to VM
 	movq GlobalRp(%rip), %rcx
 	cmp %rax, %rcx
 	jl ret1
-        movq $OP_RET, %rax             # exhausted the return stack so exit vm
-        ret
+	movq $OP_RET, %rax             # exhausted the return stack so exit vm
+	ret
 ret1:
 	addq $WSIZE, %rcx
-        movq %rcx, GlobalRp(%rip)
-        incq GlobalRtp(%rip)
+	movq %rcx, GlobalRp(%rip)
+	incq GlobalRtp(%rip)
 	movq GlobalRtp(%rip), %rbx
 	movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz  E_ret_stk_corrupt
+	cmpb $OP_ADDR, %al
+	jnz  E_ret_stk_corrupt
 	mov (%rcx), %rax
 	movq %rax, GlobalIp(%rip)		# reset the instruction ptr
-        xor %rax, %rax
+	xor %rax, %rax
 retexit:
-        ret
+	ret
 
 L_tobody:
 	LDSP
@@ -677,7 +677,7 @@ L_call:
 
 L_push_r:
 	PUSH_R
-        NEXT
+	NEXT
 L_pop_r:
 	POP_R
 	NEXT
@@ -734,39 +734,39 @@ L_twopop_r:
 	xor %rax, %rax				
 	NEXT
 L_puship:
-        mov %rbp, %rax
-        movq GlobalRp(%rip), %rbx
-        mov %rax, (%rbx)
+	mov %rbp, %rax
+	movq GlobalRp(%rip), %rbx
+	mov %rax, (%rbx)
 	movq $WSIZE, %rax
-        subq %rax, GlobalRp(%rip)
-        movq GlobalRtp(%rip), %rbx
+	subq %rax, GlobalRp(%rip)
+	movq GlobalRtp(%rip), %rbx
 	movb $OP_ADDR, %al
-        movb %al, (%rbx)
+	movb %al, (%rbx)
 	decq GlobalRtp(%rip)
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
 L_execute:	
-        mov %rbp, %rcx
-        movq GlobalRp(%rip), %rbx
-        mov %rcx, (%rbx)
+	mov %rbp, %rcx
+	movq GlobalRp(%rip), %rbx
+	mov %rcx, (%rbx)
 	movq $WSIZE, %rax 
-        sub %rax, %rbx 
+	sub %rax, %rbx
 	movq %rbx, GlobalRp(%rip)
-        movq GlobalRtp(%rip), %rbx
+	movq GlobalRtp(%rip), %rbx
 	movb $OP_ADDR, (%rbx)
 	dec %rbx
-        movq %rbx, GlobalRtp(%rip)
+	movq %rbx, GlobalRtp(%rip)
 	LDSP
-        add %rax, %rbx
+	add %rax, %rbx
 	STSP
-        mov (%rbx), %rax
+	mov (%rbx), %rax
 	dec %rax
 	mov %rax, %rbp
 	INC_DTSP
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
 L_definition:
-        mov %rbp, %rbx
+	mov %rbp, %rbx
 	movq $WSIZE, %rax
 	inc %rbx
 	mov (%rbx), %rcx # address to execute
@@ -782,23 +782,23 @@ L_definition:
 	movq %rbx, GlobalRtp(%rip)
 	dec %rcx
 	mov %rcx, %rbp
-        xor %rax, %rax	
+	xor %rax, %rax
 	NEXT
 L_rfetch:
-        movq GlobalRp(%rip), %rbx
-        addq $WSIZE, %rbx
-        movq (%rbx), %rax
-        LDSP
-        mov %rax, (%rbx)
+	movq GlobalRp(%rip), %rbx
+	addq $WSIZE, %rbx
+	movq (%rbx), %rax
+	LDSP
+	mov %rax, (%rbx)
 	movq $WSIZE, %rax
-        subq %rax, GlobalSp(%rip)
-        movq GlobalRtp(%rip), %rbx
-        inc %rbx
-        movb (%rbx), %al
-        movq GlobalTp(%rip), %rbx
-        movb %al, (%rbx)
-        DEC_DTSP
-        xor %rax, %rax
+	subq %rax, GlobalSp(%rip)
+	movq GlobalRtp(%rip), %rbx
+	inc %rbx
+	movb (%rbx), %al
+	movq GlobalTp(%rip), %rbx
+	movb %al, (%rbx)
+	DEC_DTSP
+	xor %rax, %rax
 	NEXT
 L_tworfetch:
 	movq GlobalRp(%rip), %rbx
@@ -850,80 +850,80 @@ L_spfetch:
 	xor %rax, %rax 
 	NEXT
 L_i:
-        movq GlobalRtp(%rip), %rbx
-        movb 3(%rbx), %al
-        movq GlobalTp(%rip), %rbx
-	movb %al, (%rbx)
-	dec %rbx
-	movq %rbx, GlobalTp(%rip)
-        movq GlobalRp(%rip), %rbx
-        movq 3*WSIZE(%rbx), %rax
-        LDSP
-        mov %rax, (%rbx)
-	movq $WSIZE, %rax
-        sub %rax, %rbx 
-	STSP
-        xor %rax, %rax
-        NEXT
-L_j:
-        movq GlobalRtp(%rip), %rbx
-        movb 6(%rbx), %al
+	movq GlobalRtp(%rip), %rbx
+	movb 3(%rbx), %al
 	movq GlobalTp(%rip), %rbx
 	movb %al, (%rbx)
 	dec %rbx
 	movq %rbx, GlobalTp(%rip)
-        movq GlobalRp(%rip), %rbx
-        movq 6*WSIZE(%rbx), %rax
-        LDSP
-        mov %rax, (%rbx)
+	movq GlobalRp(%rip), %rbx
+	movq 3*WSIZE(%rbx), %rax
+	LDSP
+	mov %rax, (%rbx)
 	movq $WSIZE, %rax
-        sub %rax, %rbx
+	sub %rax, %rbx
 	STSP
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
+L_j:
+	movq GlobalRtp(%rip), %rbx
+	movb 6(%rbx), %al
+	movq GlobalTp(%rip), %rbx
+	movb %al, (%rbx)
+	dec %rbx
+	movq %rbx, GlobalTp(%rip)
+	movq GlobalRp(%rip), %rbx
+	movq 6*WSIZE(%rbx), %rax
+	LDSP
+	mov %rax, (%rbx)
+	movq $WSIZE, %rax
+	sub %rax, %rbx
+	STSP
+	xor %rax, %rax
+	NEXT
 
 L_loop:
-        movq GlobalRtp(%rip), %rbx
-        inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz  E_ret_stk_corrupt
-        movq GlobalRp(%rip), %rbx
+	movq GlobalRtp(%rip), %rbx
+	inc %rbx
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz  E_ret_stk_corrupt
+	movq GlobalRp(%rip), %rbx
 	movq $WSIZE, %rax
 	add %rax, %rbx
 	mov (%rbx), %rdx
 	add %rax, %rbx
 	mov (%rbx), %rcx
 	add %rax, %rbx
-        mov (%rbx), %rax
-        inc %rax
+	mov (%rbx), %rax
+	inc %rax
 	cmp %rcx, %rax	
-        jz L_unloop
+	jz L_unloop
 loop1:	
-        mov %rax, (%rbx)	# set loop counter to next value
+	mov %rax, (%rbx)	# set loop counter to next value
 	mov %rdx, %rbp		# set instruction ptr to start of loop
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
 
 L_unloop:
 	UNLOOP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_plusloop:
 	push %rbp
 	movq GlobalRtp(%rip), %rbx
-        inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz  E_ret_stk_corrupt
+	inc %rbx
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz  E_ret_stk_corrupt
 	movq $WSIZE, %rax
 	LDSP
 	add %rax, %rbx
 	mov (%rbx), %rbp	# get loop increment 
 	STSP
 	INC_DTSP		
-        movq GlobalRp(%rip), %rbx
+	movq GlobalRp(%rip), %rbx
 	add %rax, %rbx		# get ip and save in rdx
 	mov (%rbx), %rdx
 	add %rax, %rbx
@@ -985,9 +985,9 @@ L_count:
 
 L_ival:
 	LDSP
-        mov %rbp, %rcx
-        inc %rcx
-        mov (%rcx), %rax
+	mov %rbp, %rcx
+	inc %rcx
+	mov (%rcx), %rax
 	addq $WSIZE-1, %rcx
 	mov %rcx, %rbp
 	mov %rax, (%rbx)
@@ -1027,11 +1027,11 @@ L_ptr:
 	NEXT
 
 L_fval:
-        mov %rbp, %rbx
-        inc %rbx
-        movq GlobalSp(%rip), %rcx
-        subq $WSIZE, %rcx
-        mov (%rbx), %rax
+	mov %rbp, %rbx
+	inc %rbx
+	movq GlobalSp(%rip), %rcx
+	subq $WSIZE, %rcx
+	mov (%rbx), %rax
 	mov %rax, (%rcx)
 	movq WSIZE(%rbx), %rax
 	movq %rax, WSIZE(%rcx)
@@ -1111,14 +1111,14 @@ L_zerogt:
 	NEXT
 
 L_within:
-        LDSP                       # stack: a b c 
-        movq 2*WSIZE(%rbx), %rcx   # rcx = b
+	LDSP                       # stack: a b c
+	movq 2*WSIZE(%rbx), %rcx   # rcx = b
 	movq WSIZE(%rbx), %rax     # rax = c
 	sub %rcx, %rax            # rax = c - b
 	INC_DSP     
 	INC_DSP
 	movq WSIZE(%rbx), %rdx     # rdx = a
-        sub %rcx, %rdx            # rdx = a - b
+	sub %rcx, %rdx            # rdx = a - b
 	cmp %rax, %rdx
 	movq $0, %rax
 	setb %al
@@ -1131,7 +1131,7 @@ L_within:
 	dec %rbx
 	movq %rbx, GlobalTp(%rip)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_deq:
 	movq GlobalTp(%rip), %rbx
@@ -1242,11 +1242,11 @@ L_querydupexit:
 
 L_swap:
 	SWAP
-        NEXT
+	NEXT
 
 L_over:
 	OVER
-        NEXT
+	NEXT
 
 L_rot:
 	push %rbp
@@ -1263,8 +1263,8 @@ L_rot:
 	mov (%rbp), %rcx
 	mov %rdx, (%rbp)
 	mov %rcx, (%rbx)
-        movq GlobalTp(%rip), %rbx
-        inc %rbx
+	movq GlobalTp(%rip), %rbx
+	inc %rbx
 	mov %rbx, %rbp
 	movw (%rbx), %cx
 	addq $2, %rbx
@@ -1300,15 +1300,15 @@ L_minusrot:
 	NEXT
 
 L_nip:
-        SWAP
-        addq $WSIZE, GlobalSp(%rip)
-        INC_DTSP
-        NEXT
+	SWAP
+	addq $WSIZE, GlobalSp(%rip)
+	INC_DTSP
+	NEXT
 
 L_tuck:
-        SWAP
-        OVER
-        NEXT
+	SWAP
+	OVER
+	NEXT
 
 L_pick:
 	LDSP
@@ -1397,11 +1397,11 @@ L_depth:
 	subq %rax, GlobalSp(%rip)
 	STD_IVAL
 	xor %rax, %rax
-        ret
+	ret
 
 L_2drop:
 	FDROP
-        NEXT
+	NEXT
 
 L_f2drop:
 	FDROP
@@ -1409,21 +1409,21 @@ L_f2drop:
 	NEXT
 
 L_f2dup:
-        FOVER
+	FOVER
 	FOVER
 	NEXT
 
 L_2dup:
 	FDUP
-        NEXT
+	NEXT
 
 L_2swap:
 	FSWAP	
-        NEXT
+	NEXT
 
 L_2over:
 	FOVER
-        NEXT
+	NEXT
 
 L_2rot:
 	LDSP
@@ -1455,7 +1455,7 @@ L_2rot:
 	mov %rcx, %rbx
 	movw %ax, (%rbx)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_question:
 	FETCH $OP_IVAL
@@ -1467,15 +1467,15 @@ L_fetch:
 	NEXT
 
 L_store:
-        movq GlobalTp(%rip), %rbx
+	movq GlobalTp(%rip), %rbx
 	inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz E_not_addr
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz E_not_addr
 	movq $WSIZE, %rax
 	LDSP
-        add %rax, %rbx
-        mov (%rbx), %rcx	# address to store to in rcx
+	add %rax, %rbx
+	mov (%rbx), %rcx	# address to store to in rcx
 	add %rax, %rbx
 	mov (%rbx), %rdx	# value to store in rdx
 	STSP
@@ -1502,7 +1502,7 @@ L_cfetch:
 	movb (%rcx), %al
 	mov %rax, (%rbx)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_cstore:
 	movq GlobalTp(%rip), %rdx
@@ -1536,7 +1536,7 @@ L_wfetch:
 	LDSP
 	movq %rax, WSIZE(%rbx)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_wstore:
 	movq $WSIZE, %rax
@@ -1557,59 +1557,59 @@ L_wstore:
 	addq %rax, GlobalSp(%rip)
 	INC_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_sffetch:
 	movq $WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        INC_DTSP
-        movq GlobalTp(%rip), %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz E_not_addr
-        movb $OP_IVAL, (%rbx)
-        dec %rbx
-        movb $OP_IVAL, (%rbx)
-        DEC_DTSP
+	addq %rax, GlobalSp(%rip)
+	INC_DTSP
+	movq GlobalTp(%rip), %rbx
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz E_not_addr
+	movb $OP_IVAL, (%rbx)
+	dec %rbx
+	movb $OP_IVAL, (%rbx)
 	DEC_DTSP
-        LDSP
-        mov (%rbx), %rbx
-        flds (%rbx)
+	DEC_DTSP
+	LDSP
+	mov (%rbx), %rbx
+	flds (%rbx)
 	movq $WSIZE, %rax
-        subq %rax, GlobalSp(%rip)
-        LDSP
-        fstp (%rbx)
-        subq %rax, GlobalSp(%rip)
+	subq %rax, GlobalSp(%rip)
+	LDSP
+	fstp (%rbx)
+	subq %rax, GlobalSp(%rip)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_sfstore:
 	movq $WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        INC_DTSP
-        movq GlobalTp(%rip), %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz E_not_addr
-        LDSP
-        INC_DSP
-        fld (%rbx)              # load the f number into NDP
-        DEC_DSP
-        mov (%rbx), %rbx          # load the dest address
-        fstps (%rbx)             # store as single precision float
+	addq %rax, GlobalSp(%rip)
+	INC_DTSP
+	movq GlobalTp(%rip), %rbx
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz E_not_addr
+	LDSP
+	INC_DSP
+	fld (%rbx)              # load the f number into NDP
+	DEC_DSP
+	mov (%rbx), %rbx          # load the dest address
+	fstps (%rbx)             # store as single precision float
 	movq $WSIZE, %rax
 	salq $1, %rax
-        addq %rax, GlobalSp(%rip)
+	addq %rax, GlobalSp(%rip)
 	INC2_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_dffetch:	
-        movq GlobalTp(%rip), %rbx
+	movq GlobalTp(%rip), %rbx
 	inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz E_not_addr
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz E_not_addr
 	movb $OP_IVAL, (%rbx)
 	dec %rbx
 	movb $OP_IVAL, (%rbx)
@@ -1630,11 +1630,11 @@ L_dffetch:
 	NEXT
 
 L_dfstore:
-        movq GlobalTp(%rip), %rbx
+	movq GlobalTp(%rip), %rbx
 	inc %rbx
-        movb (%rbx), %al
-        cmpb $OP_ADDR, %al
-        jnz  E_not_addr
+	movb (%rbx), %al
+	cmpb $OP_ADDR, %al
+	jnz  E_not_addr
 	addq $2, %rbx
 	movq %rbx, GlobalTp(%rip)
 	LDSP
@@ -1655,7 +1655,7 @@ L_dfstore:
 
 L_abs:
 	_ABS
-        NEXT
+	NEXT
 
 L_max:
 	movq $WSIZE, %rax
@@ -1675,7 +1675,7 @@ max1:
 maxexit:
 	INC_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_min:
 	movq $WSIZE, %rax
@@ -1695,7 +1695,7 @@ min1:
 minexit:
 	INC_DTSP
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_dmax:
 	FOVER
@@ -1735,34 +1735,34 @@ dmin1:
 
 #  L_dtwostar and L_dtwodiv are valid for two's-complement systems
 L_dtwostar:
-        LDSP
-        INC_DSP
-        movq WSIZE(%rbx), %rax
-        mov %rax, %rcx
-        salq $1, %rax
-        movq %rax, WSIZE(%rbx)
+	LDSP
+	INC_DSP
+	movq WSIZE(%rbx), %rax
+	mov %rax, %rcx
+	salq $1, %rax
+	movq %rax, WSIZE(%rbx)
 	shrq $8*WSIZE-1, %rcx
-        mov (%rbx), %rax
-        salq $1, %rax
-        or  %rcx, %rax
-        mov %rax, (%rbx)
-        xor %rax, %rax
-        NEXT
+	mov (%rbx), %rax
+	salq $1, %rax
+	or  %rcx, %rax
+	mov %rax, (%rbx)
+	xor %rax, %rax
+	NEXT
 
 L_dtwodiv:
 	LDSP
 	INC_DSP
 	mov (%rbx), %rax
-        mov %rax, %rcx
-        sarq $1, %rax
-        mov %rax, (%rbx)
+	mov %rax, %rcx
+	sarq $1, %rax
+	mov %rax, (%rbx)
 	shlq $8*WSIZE-1, %rcx
-        movq WSIZE(%rbx), %rax
-        shrq $1, %rax
-        or %rcx, %rax
-        movq %rax, WSIZE(%rbx)
-        xor %rax, %rax
-        NEXT
+	movq WSIZE(%rbx), %rax
+	shrq $1, %rax
+	or %rcx, %rax
+	movq %rax, WSIZE(%rbx)
+	xor %rax, %rax
+	NEXT
 
 L_add:
 	LDSP
@@ -1778,25 +1778,25 @@ L_add:
 	andb %ah, %al		# and the two types to preserve addr type
 	inc %rbx
 	movb %al, (%rbx)
-        xor %rax, %rax
-        NEXT
+	xor %rax, %rax
+	NEXT
 
 L_div:
 	movq $WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        INC_DTSP
-        LDSP
-        mov (%rbx), %rax
-        cmpq $0, %rax
-        jz  E_div_zero	
+	addq %rax, GlobalSp(%rip)
+	INC_DTSP
+	LDSP
+	mov (%rbx), %rax
+	cmpq $0, %rax
+	jz  E_div_zero
 	INC_DSP
-        mov (%rbx), %rax
+	mov (%rbx), %rax
 	cqo
-        idivq -WSIZE(%rbx)
-        mov %rax, (%rbx)
+	idivq -WSIZE(%rbx)
+	mov %rax, (%rbx)
 	xor %rax, %rax
 divexit:
-        ret
+	ret
 
 L_mod:
 	call L_div
@@ -1887,7 +1887,7 @@ L_dnegate:
 L_dplus:
 	DPLUS
 #	NEXT
-        ret
+	ret
 
 L_dminus:
 	DMINUS
@@ -1989,21 +1989,21 @@ L_mplus:
 	NEXT
 
 L_mslash:
-        LDSP
+	LDSP
 	movq $WSIZE, %rax
-        INC_DTSP
+	INC_DTSP
 	add %rax, %rbx
-        mov (%rbx), %rcx
+	mov (%rbx), %rcx
 	INC_DTSP
 	add %rax, %rbx
 	STSP
-        cmpq $0, %rcx
+	cmpq $0, %rcx
 	je  E_div_zero
-        mov (%rbx), %rdx
+	mov (%rbx), %rdx
 	add %rax, %rbx
 	mov (%rbx), %rax
-        idivq %rcx
-        mov %rax, (%rbx)
+	idivq %rcx
+	mov %rax, (%rbx)
 	xor %rax, %rax		
 	NEXT
 
@@ -2068,32 +2068,32 @@ L_utsslashmod:
 
 L_tabs:
 # Triple length absolute value (needed by L_stsslashrem, STS/REM)
-        LDSP
-        INC_DSP
-        mov (%rbx), %rcx
-        mov %rcx, %rax
-        cmpq $0, %rax
-        jl tabs1
-        xor %rax, %rax
-        ret
+	LDSP
+	INC_DSP
+	mov (%rbx), %rcx
+	mov %rcx, %rax
+	cmpq $0, %rax
+	jl tabs1
+	xor %rax, %rax
+	ret
 tabs1:
-        addq $2*WSIZE, %rbx
-        mov (%rbx), %rax
-        clc
-        subq $1, %rax
-        not %rax
-        mov %rax, (%rbx)
+	addq $2*WSIZE, %rbx
+	mov (%rbx), %rax
+	clc
+	subq $1, %rax
+	not %rax
+	mov %rax, (%rbx)
 	DEC_DSP
 	mov (%rbx), %rax
 	sbbq $0, %rax
 	not %rax
 	mov %rax, (%rbx)
-        mov %rcx, %rax
-        sbbq $0, %rax
-        not %rax
-        mov %rax, -WSIZE(%rbx)
-        xor %rax, %rax
-        ret
+	mov %rcx, %rax
+	sbbq $0, %rax
+	not %rax
+	mov %rax, -WSIZE(%rbx)
+	xor %rax, %rax
+	ret
 
 L_stsslashrem:
 # Divide signed triple length by signed single length to give a
@@ -2328,50 +2328,50 @@ L_smslashrem:
 
 L_stof:
 	movq $WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        INC_DTSP
-        LDSP
-        fild (%rbx)
-        movq GlobalTp(%rip), %rbx
-        movb $OP_IVAL, (%rbx)
-        dec %rbx
-        movb $OP_IVAL, (%rbx)
+	addq %rax, GlobalSp(%rip)
+	INC_DTSP
+	LDSP
+	fild (%rbx)
+	movq GlobalTp(%rip), %rbx
+	movb $OP_IVAL, (%rbx)
+	dec %rbx
+	movb $OP_IVAL, (%rbx)
 	DEC_DTSP
 	DEC_DTSP
-        LDSP
+	LDSP
 	movq $WSIZE, %rax
-        sub %rax, %rbx
-        fstp (%rbx)
+	sub %rax, %rbx
+	fstp (%rbx)
 	salq $1, %rax
-        subq %rax, GlobalSp(%rip)
+	subq %rax, GlobalSp(%rip)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_dtof:
-        LDSP
+	LDSP
 	movq $WSIZE, %rax
 	add %rax, %rbx
 	mov (%rbx), %rax
 	xchgq WSIZE(%rbx), %rax
 	mov %rax, (%rbx)
-        fildq (%rbx)
-        fstp (%rbx)
+	fildq (%rbx)
+	fstp (%rbx)
 	xor %rax, %rax	
 	NEXT	
 
 L_froundtos:
 	movq $WSIZE, %rax
-        addq %rax, GlobalSp(%rip)
-        LDSP
-        fld (%rbx)
-        add %rax, %rbx
-        fistp (%rbx)
-        INC_DTSP
-        movq GlobalTp(%rip), %rbx
-        inc %rbx
-        movb $OP_IVAL, (%rbx)
+	addq %rax, GlobalSp(%rip)
+	LDSP
+	fld (%rbx)
+	add %rax, %rbx
+	fistp (%rbx)
+	INC_DTSP
+	movq GlobalTp(%rip), %rbx
+	inc %rbx
+	movb $OP_IVAL, (%rbx)
 	xor %rax, %rax
-        NEXT
+	NEXT
 
 L_ftrunctos:
 	LDSP


### PR DESCRIPTION
Most lines began with tabs, but some began with 8 spaces. I tried to make it uniform on tabs.